### PR TITLE
Infinite scroll issue

### DIFF
--- a/content_scripts/scroller.js
+++ b/content_scripts/scroller.js
@@ -280,7 +280,10 @@ const CoreScroller = {
 
       if (delta && performScroll(element, direction, sign * delta)) {
         totalDelta += delta;
-        return requestAnimationFrame(animate);
+
+        setTimeout(() => { requestAnimationFrame(animate) }, 10);
+        return 1
+        // return requestAnimationFrame(animate);
       } else {
         // We're done.
         handlerStack.remove(cancelEventListener);


### PR DESCRIPTION
## Description
In recent version, sometimes, when pressing "d" (or "u", "j", "k" as well), the page is scrolled continuously until end of the page. 

After some debug, I found that it looks like the main eventloop is so busy, so it does not receive the keyup event until end of the page is reached. 
#### Solution:   
Instead of call directly browser function to scroll, we call it via setTimeout, so the event loop can be activated
#### Disclaim: 
Im not javascript or FE developer so this fix might be not the most optimized (and cleaned) one. But at least the problem is resolved (for me ) while wating for a better solution from the author. 

